### PR TITLE
Added URI encoding/decoding for notifications description.

### DIFF
--- a/lib/withings/notification_description.rb
+++ b/lib/withings/notification_description.rb
@@ -1,13 +1,12 @@
 class Withings::NotificationDescription
-  attr_reader :callback_url, :description, :expires_at
+  attr_reader :callback_url, :expires_at # :description
   def initialize(params = {})
     params = params.stringify_keys
-    @callback_url = params['callbackurl']
-    @description = URI::decode(params['comment'])
+    @callback_url = params['comment']
     @expires_at = Time.at(params['expires'])
   end
 
   def to_s
-    "[Notification #{self.callback_url} / #{self.description}, #{self.expires_at}]"
+    "[Notification #{self.callback_url}, #{self.expires_at}]"
   end
 end

--- a/lib/withings/notification_description.rb
+++ b/lib/withings/notification_description.rb
@@ -3,7 +3,7 @@ class Withings::NotificationDescription
   def initialize(params = {})
     params = params.stringify_keys
     @callback_url = params['callbackurl']
-    @description = params['comment']
+    @description = URI::decode(params['comment'])
     @expires_at = Time.at(params['expires'])
   end
 

--- a/lib/withings/user.rb
+++ b/lib/withings/user.rb
@@ -23,7 +23,7 @@ class Withings::User
   end
 
   def subscribe_notification(callback_url, description, device = Withings::SCALE)
-    connection.get_request('/notify', :action => :subscribe, :callbackurl => callback_url, :comment => description, :appli => device)
+    connection.get_request('/notify', :action => :subscribe, :callbackurl => callback_url, :comment => URI::encode(description), :appli => device)
   end
 
   def revoke_notification(callback_url, device = Withings::SCALE)

--- a/lib/withings/user.rb
+++ b/lib/withings/user.rb
@@ -22,8 +22,8 @@ class Withings::User
     @oauth_token_secret = params['oauth_token_secret']
   end
 
-  def subscribe_notification(callback_url, description, device = Withings::SCALE)
-    connection.get_request('/notify', :action => :subscribe, :callbackurl => callback_url, :comment => URI::encode(description), :appli => device)
+  def create_notification(callback_url, device = Withings::SCALE)
+    connection.get_request('/notify', :action => :subscribe, :callbackurl => callback_url, :comment => callback_url, :appli => device)
   end
 
   def revoke_notification(callback_url, device = Withings::SCALE)
@@ -36,7 +36,7 @@ class Withings::User
   end
 
   # List the notifications for a device (defaults to Withings::SCALE), pass nil to list all devices.
-  def list_notifications(device = Withings::SCALE)
+  def notifications(device = Withings::SCALE)
     options = (device.nil? ? {} : {:appli => device})
     response = connection.get_request('/notify', options.merge({:action => :list}))
     response['profiles'].map do |item|


### PR DESCRIPTION
I found a bug earlier that without encoding the description of a new notification it will fail but still create the notification server side, I have submitted this bug to Withings already as these show up with callback_urls that are nil, but are still in the list. 
This pull request adds URI encoding and decoding to the description. The examples in the readme regarding notifications are not possible as they will fail with response code 432 "The signature (using Oauth) is invalid.", because the description is not getting URI encoded.
